### PR TITLE
Github Action to build and publish docker image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,46 @@
+name: Build Docker Image
+on:
+  push:
+    branches:
+      - "!*"
+    tags:
+      - "*"
+env:
+  REGISTRY: harbor.mobiledgex.net
+
+jobs:
+
+  build-docker-image:
+    name: Build the go-swagger image
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+    steps:
+      -
+        name: Compute docker image meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/mobiledgex/go-swagger/swagger
+      -
+        name: Set up builder username
+        run: git config --global user.name github
+      -
+        name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Log in to registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      -
+        name: Build swagger image
+        uses: docker/build-push-action@v2
+        id: build
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
On every tag, a docker image will be built and published to
`harbor.mobiledgex.net/mobiledgex/go-swagger/swagger:<tag>`